### PR TITLE
Design: 게시글 4개 미만일경우 게시글 카드의 넓이 잘못됨 이를 수정완료

### DIFF
--- a/src/pages/HomePage/HomePage.styles.js
+++ b/src/pages/HomePage/HomePage.styles.js
@@ -6,7 +6,7 @@ export const PostList = styled.ul`
   width: 1320px;
   margin: 0 auto;
   margin-bottom: 20px;
-  display: grid;
+  display: flex;
   grid-template-columns: repeat(4, auto);
   gap: 20px;
   flex-wrap: wrap;


### PR DESCRIPTION
PostList styled-component의 display grid에서 flex로 변경함